### PR TITLE
Fix 'debugger' line in main.js

### DIFF
--- a/BlazorInputMask/wwwroot/js/main.js
+++ b/BlazorInputMask/wwwroot/js/main.js
@@ -2,15 +2,14 @@
 var customMask = null;
 
 window.mask = (id, mask, isRegEx, destroy, dotnetHelper) => {
-    debugger;
-    var pattern;    
+    var pattern;
     if (isRegEx)
         pattern = new RegExp(mask);
     else
         pattern = mask;
     if (customMask != null && destroy) {
         customMask.destroy();
-    }    
+    }
     customMask = IMask(
         document.getElementById(id), {
         mask: pattern,
@@ -20,4 +19,3 @@ window.mask = (id, mask, isRegEx, destroy, dotnetHelper) => {
         }
     });
 };
-


### PR DESCRIPTION
The `debugger` line forces the application using this package to stop and debug the javascript file, which is annoying if you don't want to.

9454e1c BlazorInputMask/wwwroot/js/main.js

Maybe there is a better fix leaving the line as it is and not using it when the package is published. For now i just deleted it.